### PR TITLE
bug/fix project length tracker graph

### DIFF
--- a/GTD/Meta/Analytics.md
+++ b/GTD/Meta/Analytics.md
@@ -228,7 +228,7 @@ groupedActivatedProjectBuckets.forEach(gb => {
 const chartData = {
     type: 'bar',
     data: {
-        labels: Object.keys(completedProjectData),
+        labels: Object.keys(activatedProjectData),
         datasets: [{
                 label: 'Completed Project Durations',
                 data: Object.values(completedProjectData),


### PR DESCRIPTION
Labels for the project length tracker graph were relying on completed project weeks rather than activated project weeks. This meant that the graph didn't display when there were no completed projects.